### PR TITLE
Benefit from the GitHub API to get latest released version binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,11 @@ You just have to download the binary compatible with your platform to a director
 #### Linux
 
 ```bash
-# Check out the latest release available on github <https://github.com/scaleway/scaleway-cli/releases/latest>
-VERSION="2.5.1"
+# Use the latest release available on github (<https://github.com/scaleway/scaleway-cli/releases/latest>)
+VERSION="$(curl --no-progress-meter "https://api.github.com/repos/scaleway/scaleway-cli/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")' | cut -c 2-)"
+
+# Or use a specific (older) version (check out the available releases on github <https://github.com/scaleway/scaleway-cli/releases>)
+# VERSION="2.4.0"
 
 # Download the release from github
 sudo curl -o /usr/local/bin/scw -L "https://github.com/scaleway/scaleway-cli/releases/download/v${VERSION}/scaleway-cli_${VERSION}_linux_amd64"


### PR DESCRIPTION
I noticed the example of command to get the static-compiled binary requires to manually type in the desired version.

This PR changes the command to automatically get the latest version from the GitHub API thus avoiding:

* User manipulation
* Updates to the README when a new version is released

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request.
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

```release-note
NONE
```
